### PR TITLE
Add proxy to original `interrupt`

### DIFF
--- a/multi-progress.js
+++ b/multi-progress.js
@@ -10,12 +10,14 @@ var emptyObj = {
       terminate: function () {},
       update: function () {},
       render: function () {},
+      interrupt: function () {},
     };
   },
   terminate: function () {},
   move: function () {},
   tick: function () {},
   update: function () {},
+  interrupt: function () {},
   isTTY: false,
 };
 
@@ -51,6 +53,7 @@ MultiProgress.prototype = {
     bar.otick = bar.tick;
     bar.oterminate = bar.terminate;
     bar.oupdate = bar.update;
+    bar.ointerrupt = bar.interrupt;
     bar.tick = function(value, options) {
       self.tick(index, value, options);
     };
@@ -62,6 +65,9 @@ MultiProgress.prototype = {
     };
     bar.update = function(value, options){
       self.update(index, value, options);
+    };
+    bar.interrupt = function(value) {
+      self.interrupt(index, value);
     };
 
     return bar;
@@ -91,6 +97,14 @@ MultiProgress.prototype = {
     if (bar) {
       this.move(index);
       bar.oupdate(value, options);
+    }
+  },
+
+  interrupt: function(index, value, options) {
+    var bar = this.bars[index];
+    if (bar) {
+      this.move(index);
+      bar.ointerrupt(value, options);
     }
   }
 };


### PR DESCRIPTION
I've implemented the `interrupt` command of the original `progress` npm package. 

What happens is that the message appears, with the progress bar that triggered it below it. When the other bars `tick` they get rendered below the one that triggered the interrupt.

For my usecase this is fine, as the ticks follow eachother very quickly and there aren't a lot of interrupts. If you have to wait multiple seconds for the other progress bars to re-appear, or interrupt a lot, it will be a less ideal situation. Also, it isn't clear which of the bars triggered an interrupt, I solved that in the interrupt message itself.

My output looks like this:

```
Duplicate on JSON page 24: RP-T-2009-99-31(R)
Duplicate on JSON page 24: RP-T-2009-98-28(V)
Duplicate on JSON page 26: RP-T-1981-80-3(V)
Downloading JSON [===                 ] 320/2451 68.0s
Downloading OAI  [=                   ] 260/6641 240.6s
```