### PR TITLE
V3 is not backwards compatible and example is not accurate

### DIFF
--- a/multi-progress.js
+++ b/multi-progress.js
@@ -25,6 +25,7 @@ module.exports = class MultiProgress {
   constructor(stream) {
     this.stream = stream || process.stderr;
     this.isTTY = this.stream.isTTY;
+
     if (!this.isTTY) {
       return mockInstance;
     }
@@ -35,6 +36,7 @@ module.exports = class MultiProgress {
   
     return this;
   }
+
   newBar(schema, options) {
     options.stream = this.stream;
     var bar = new Progress(schema, options);
@@ -63,15 +65,18 @@ module.exports = class MultiProgress {
     };
     return bar;
   }
+
   terminate() {
     this.move(this.bars.length);
     this.stream.clearLine();
     this.stream.cursorTo(0);
   }
+
   move(index) {
     this.stream.moveCursor(0, index - this.cursor);
     this.cursor = index;
   }
+
   tick(index, value, options) {
     const bar = this.bars[index];
     if (bar) {
@@ -79,6 +84,7 @@ module.exports = class MultiProgress {
       bar.otick(value, options);
     }
   }
+
   update(index, value, options) {
     const bar = this.bars[index];
     if (bar) {

--- a/multi-progress.js
+++ b/multi-progress.js
@@ -42,10 +42,12 @@ module.exports = class MultiProgress {
     var bar = new Progress(schema, options);
     this.bars.push(bar);
     var index = this.bars.length - 1;
+
     // alloc line
     this.move(index);
     this.stream.write('\n');
     this.cursor += 1;
+
     // replace original
     var self = this;
     bar.otick = bar.tick;
@@ -63,6 +65,7 @@ module.exports = class MultiProgress {
     bar.update = function(value, options){
       self.update(index, value, options);
     };
+
     return bar;
   }
 

--- a/multi-progress.js
+++ b/multi-progress.js
@@ -1,6 +1,8 @@
 // from https://gist.github.com/nuxlli/b425344b92ac1ff99c74
 // with some modifications & additions
 
+const Progress = require('progress');
+
 const mockBar = {
   tick() {},
   terminate() {},
@@ -19,82 +21,69 @@ const mockInstance = {
   isTTY: false,
 };
 
-module.exports = (Progress) => {
-  class MultiProgress {
-    constructor(stream) {
-      this.stream = stream || process.stderr;
-      this.isTTY = this.stream.isTTY;
-
-      if (!this.isTTY) {
-        return mockInstance;
-      }
-      
-      this.cursor = 0;
-      this.bars = [];
-      this.terminates = 0;
+module.exports = class MultiProgress {
+  constructor(stream) {
+    this.stream = stream || process.stderr;
+    this.isTTY = this.stream.isTTY;
+    if (!this.isTTY) {
+      return mockInstance;
+    }
     
-      return this;
-    }
-
-    newBar(schema, options) {
-      options.stream = this.stream;
-      var bar = new Progress(schema, options);
-      this.bars.push(bar);
-      var index = this.bars.length - 1;
-
-      // alloc line
+    this.cursor = 0;
+    this.bars = [];
+    this.terminates = 0;
+  
+    return this;
+  }
+  newBar(schema, options) {
+    options.stream = this.stream;
+    var bar = new Progress(schema, options);
+    this.bars.push(bar);
+    var index = this.bars.length - 1;
+    // alloc line
+    this.move(index);
+    this.stream.write('\n');
+    this.cursor += 1;
+    // replace original
+    var self = this;
+    bar.otick = bar.tick;
+    bar.oterminate = bar.terminate;
+    bar.oupdate = bar.update;
+    bar.tick = function(value, options) {
+      self.tick(index, value, options);
+    };
+    bar.terminate = function() {
+      self.terminates += 1;
+      if (self.terminates === self.bars.length) {
+        self.terminate();
+      }
+    };
+    bar.update = function(value, options){
+      self.update(index, value, options);
+    };
+    return bar;
+  }
+  terminate() {
+    this.move(this.bars.length);
+    this.stream.clearLine();
+    this.stream.cursorTo(0);
+  }
+  move(index) {
+    this.stream.moveCursor(0, index - this.cursor);
+    this.cursor = index;
+  }
+  tick(index, value, options) {
+    const bar = this.bars[index];
+    if (bar) {
       this.move(index);
-      this.stream.write('\n');
-      this.cursor += 1;
-
-      // replace original
-      var self = this;
-      bar.otick = bar.tick;
-      bar.oterminate = bar.terminate;
-      bar.oupdate = bar.update;
-      bar.tick = function(value, options) {
-        self.tick(index, value, options);
-      };
-      bar.terminate = function() {
-        self.terminates += 1;
-        if (self.terminates === self.bars.length) {
-          self.terminate();
-        }
-      };
-      bar.update = function(value, options){
-        self.update(index, value, options);
-      };
-
-      return bar;
-    }
-
-    terminate() {
-      this.move(this.bars.length);
-      this.stream.clearLine();
-      this.stream.cursorTo(0);
-    }
-
-    move(index) {
-      this.stream.moveCursor(0, index - this.cursor);
-      this.cursor = index;
-    }
-
-    tick(index, value, options) {
-      const bar = this.bars[index];
-      if (bar) {
-        this.move(index);
-        bar.otick(value, options);
-      }
-    }
-
-    update(index, value, options) {
-      const bar = this.bars[index];
-      if (bar) {
-        this.move(index);
-        bar.oupdate(value, options);
-      }
+      bar.otick(value, options);
     }
   }
-
-  return MultiProgress;
-};
+  update(index, value, options) {
+    const bar = this.bars[index];
+    if (bar) {
+      this.move(index);
+      bar.oupdate(value, options);
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/pitaj/multi-progress/issues"
   },
   "homepage": "https://github.com/pitaj/multi-progress",
-  "dependencies": {
+  "peerDependencies": {
     "progress": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/pitaj/multi-progress/issues"
   },
   "homepage": "https://github.com/pitaj/multi-progress",
-  "peerDependencies": {
+  "dependencies": {
     "progress": "^2.0.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,6 @@ Install with npm: `npm install multi-progress`
 var Multiprogress = require("multi-progress");
 
 // spawn an instance with the optional stream to write to
-// use of `new` is optional
 var multi = new Multiprogress(process.stderr);
 
 // create a progress bar


### PR DESCRIPTION
Updated to v3 today and noticed that the example doesn't work. Poking around I created some minor changes to support backwards compatibility. 

- Moved the progress peer dependency to a dependency. Peer dependencies aren't automatically downloaded, the alternative to this would have been to update the documentation to encourage installing Progress in tandem. 
- Import Progress locally and export a class rather than a function. Doing this ensures backwards compatibility with V2. The alternative would have been to update the documentation to show importing progress and passing progress into the default export of multi-progress

I think the changes are better alternative than updating the docs as they support backwards compatibility with less work for those implementing multi-progress


